### PR TITLE
Remove boost-locale

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -53,7 +53,6 @@ jobs:
         vcpkg install --triplet x64-windows-static
         boost-geometry
         boost-iostreams
-        boost-locale
         boost-program-options
         bullet3[double-precision,multithreading]
         ffmpeg
@@ -141,7 +140,6 @@ jobs:
         vcpkg install --triplet x64-windows
         boost-geometry
         boost-iostreams
-        boost-locale
         boost-program-options
         bullet3[double-precision,multithreading]
         ffmpeg


### PR DESCRIPTION
It turns out that we've not actually used it for years, and it's been referenced by our CMake for no reason.