### PR TITLE
Specify the permissions required to create a release

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -209,6 +209,9 @@ jobs:
     env:
       file: TEST
 
+    permissions:
+      contents: write
+
     steps:
     - uses: actions/checkout@v4
 


### PR DESCRIPTION
Because apparently this repo isn't using the default permissions.

https://github.com/softprops/action-gh-release?tab=readme-ov-file#permissions