### PR TITLE
Prevent push-dynamic from running on master

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -212,6 +212,9 @@ jobs:
     permissions:
       contents: write
 
+    # non-master or tagged master only
+    if: ${{ github.ref_name != 'master' }}
+
     steps:
     - uses: actions/checkout@v4
 


### PR DESCRIPTION
I think there's something to be said for applying this `if` to the whole thing, but this should resolve the double run issue.