### PR TITLE
Run 2019 build on 2022 image

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,13 +13,15 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        image:
-        - windows-2019
-        - windows-2022
+        msvc_version:
+        - year: 2019
+          triplet: x64-windows-2019-static
+        - year: 2022
+          triplet: x64-windows-static
 
-    name: static-${{ matrix.image }}
+    name: static-windows-${{ matrix.msvc_version }}
 
-    runs-on: ${{ matrix.image }}
+    runs-on: windows-2022
 
     steps:
     - uses: actions/checkout@v4
@@ -30,6 +32,12 @@ jobs:
         script: |
           core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
           core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
+    
+    - name: Install MSVC 2019
+      if: ${{ matrix.msvc_version.year == 2019 }}
+      run: >
+        # this is temporary, so please excuse the hardcoded paths
+        & "C:\Program Files (x86)\Microsoft Visual Studio\Installer\vs_installer.exe" modify --installPath "C:\Program Files\Microsoft Visual Studio\2022\Enterprise" --add Microsoft.VisualStudio.ComponentGroup.VC.Tools.142.x86.x64 --quiet --norestart
 
     - name: Set up vcpkg
       run: |
@@ -40,7 +48,7 @@ jobs:
 
     - name: Install vcpkg packages
       run: >
-        vcpkg install --overlay-ports=ports --triplet x64-windows-static
+        vcpkg install --overlay-ports=ports --overlay-triplets=triplets --triplet ${{ matrix.msvc_version.triplet }}
         boost-geometry
         boost-iostreams
         boost-program-options
@@ -73,35 +81,37 @@ jobs:
 
     - name: Archive pdb files
       working-directory: '${{ github.workspace }}/intermediate/pdb'
-      run: 7z a "${{ github.workspace }}/vcpkg-x64-${{ matrix.image }}-static-pdb-${{ github.sha }}.7z" installed
+      run: 7z a "${{ github.workspace }}/vcpkg-x64-windows-${{ matrix.msvc_version.year }}-static-pdb-${{ github.sha }}.7z" installed
 
     - name: Store archived pdb files
       uses: actions/upload-artifact@v4
       with:
-        name: vcpkg-x64-${{ matrix.image }}-static-pdb-${{ github.sha }}
-        path: ${{ github.workspace }}/vcpkg-x64-${{ matrix.image }}-static-pdb-${{ github.sha }}.7z
+        name: vcpkg-x64-windows-${{ matrix.msvc_version.year }}-static-pdb-${{ github.sha }}
+        path: ${{ github.workspace }}/vcpkg-x64-windows-${{ matrix.msvc_version.year }}-static-pdb-${{ github.sha }}.7z
 
     - name: Archive everything else
       working-directory: '${{ github.workspace }}/intermediate'
-      run: 7z a "${{ github.workspace }}/vcpkg-x64-${{ matrix.image }}-static-${{ github.sha }}.7z" * -x!pdb
+      run: 7z a "${{ github.workspace }}/vcpkg-x64-windows-${{ matrix.msvc_version.year }}-static-${{ github.sha }}.7z" * -x!pdb
 
     - name: Store exported vcpkg packages
       uses: actions/upload-artifact@v4
       with:
-        name: vcpkg-x64-${{ matrix.image }}-static-${{ github.sha }}
-        path: ${{ github.workspace }}/vcpkg-x64-${{ matrix.image }}-static-${{ github.sha }}.7z
+        name: vcpkg-x64-windows-${{ matrix.msvc_version.year }}-static-${{ github.sha }}
+        path: ${{ github.workspace }}/vcpkg-x64-windows-${{ matrix.msvc_version.year }}-static-${{ github.sha }}.7z
 
   dynamic:
     strategy:
       fail-fast: true
       matrix:
-        image:
-        - windows-2019
-        - windows-2022
+        msvc_version:
+        - year: 2019
+          triplet: x64-windows-2019
+        - year: 2022
+          triplet: x64-windows
 
-    name: dynamic-${{ matrix.image }}
+    name: dynamic-windows-${{ matrix.msvc_version.year }}
 
-    runs-on: ${{ matrix.image }}
+    runs-on: windows-2022
 
     steps:
     - uses: actions/checkout@v4
@@ -122,7 +132,7 @@ jobs:
 
     - name: Install vcpkg packages
       run: >
-        vcpkg install --overlay-ports=ports --triplet x64-windows
+        vcpkg install --overlay-ports=ports --overlay-triplets=triplets --triplet ${{ matrix.msvc_version.triplet }}
         boost-geometry
         boost-iostreams
         boost-program-options
@@ -155,23 +165,23 @@ jobs:
 
     - name: Archive pdb files
       working-directory: '${{ github.workspace }}/intermediate/pdb'
-      run: 7z a "${{ github.workspace }}/vcpkg-x64-${{ matrix.image }}-pdb-${{ github.sha }}.7z" installed
+      run: 7z a "${{ github.workspace }}/vcpkg-x64-windows-${{ matrix.msvc_version.year }}-pdb-${{ github.sha }}.7z" installed
 
     - name: Store archived pdb files
       uses: actions/upload-artifact@v4
       with:
-        name: vcpkg-x64-${{ matrix.image }}-pdb-${{ github.sha }}
-        path: ${{ github.workspace }}/vcpkg-x64-${{ matrix.image }}-pdb-${{ github.sha }}.7z
+        name: vcpkg-x64-windows-${{ matrix.msvc_version.year }}-pdb-${{ github.sha }}
+        path: ${{ github.workspace }}/vcpkg-x64-windows-${{ matrix.msvc_version.year }}-pdb-${{ github.sha }}.7z
 
     - name: Archive everything else
       working-directory: '${{ github.workspace }}/intermediate'
-      run: 7z a "${{ github.workspace }}/vcpkg-x64-${{ matrix.image }}-${{ github.sha }}.7z" * -x!pdb
+      run: 7z a "${{ github.workspace }}/vcpkg-x64-windows-${{ matrix.msvc_version.year }}-${{ github.sha }}.7z" * -x!pdb
 
     - name: Store exported vcpkg packages
       uses: actions/upload-artifact@v4
       with:
-        name: vcpkg-x64-${{ matrix.image }}-${{ github.sha }}
-        path: ${{ github.workspace }}/vcpkg-x64-${{ matrix.image }}-${{ github.sha }}.7z
+        name: vcpkg-x64-windows-${{ matrix.msvc_version.year }}-${{ github.sha }}
+        path: ${{ github.workspace }}/vcpkg-x64-windows-${{ matrix.msvc_version.year }}-${{ github.sha }}.7z
 
     - name: Repackage binaries for symbol server
       env:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -42,7 +42,7 @@ jobs:
 
     - name: Install vcpkg packages
       run: >
-        vcpkg install --overlay-ports=ports --overlay-triplets=triplets --triplet ${{ matrix.msvc_version.triplet }}
+        vcpkg install --overlay-ports=ports --overlay-triplets=triplets --host-triplet ${{ matrix.msvc_version.triplet }} --triplet ${{ matrix.msvc_version.triplet }}
         boost-geometry
         boost-iostreams
         boost-program-options
@@ -60,8 +60,6 @@ jobs:
     - name: Export installed vcpkg packages
       run: >
         vcpkg export
-        --overlay-triplets=triplets
-        --triplet ${{ matrix.msvc_version.triplet }}
         --x-all-installed
         --raw
         --output-dir ${{ github.workspace }}
@@ -128,7 +126,7 @@ jobs:
 
     - name: Install vcpkg packages
       run: >
-        vcpkg install --overlay-ports=ports --overlay-triplets=triplets --triplet ${{ matrix.msvc_version.triplet }}
+        vcpkg install --overlay-ports=ports --overlay-triplets=triplets --host-triplet ${{ matrix.msvc_version.triplet }} --triplet ${{ matrix.msvc_version.triplet }}
         boost-geometry
         boost-iostreams
         boost-program-options
@@ -146,8 +144,6 @@ jobs:
     - name: Export installed vcpkg packages
       run: >
         vcpkg export
-        --overlay-triplets=triplets
-        --triplet ${{ matrix.msvc_version.triplet }}
         --x-all-installed
         --raw
         --output-dir ${{ github.workspace }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -60,6 +60,7 @@ jobs:
     - name: Export installed vcpkg packages
       run: >
         vcpkg export
+        --overlay-triplets=triplets
         --triplet ${{ matrix.msvc_version.triplet }}
         --x-all-installed
         --raw
@@ -145,6 +146,7 @@ jobs:
     - name: Export installed vcpkg packages
       run: >
         vcpkg export
+        --overlay-triplets=triplets
         --triplet ${{ matrix.msvc_version.triplet }}
         --x-all-installed
         --raw

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -60,6 +60,7 @@ jobs:
     - name: Export installed vcpkg packages
       run: >
         vcpkg export
+        --triplet ${{ matrix.msvc_version.triplet }}
         --x-all-installed
         --raw
         --output-dir ${{ github.workspace }}
@@ -144,6 +145,7 @@ jobs:
     - name: Export installed vcpkg packages
       run: >
         vcpkg export
+        --triplet ${{ matrix.msvc_version.triplet }}
         --x-all-installed
         --raw
         --output-dir ${{ github.workspace }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -35,7 +35,7 @@ jobs:
     
     - name: Install MSVC 2019
       if: ${{ matrix.msvc_version.year == 2019 }}
-      run: >
+      run: |
         # this is temporary, so please excuse the hardcoded paths
         & "C:\Program Files (x86)\Microsoft Visual Studio\Installer\vs_installer.exe" modify --installPath "C:\Program Files\Microsoft Visual Studio\2022\Enterprise" --add Microsoft.VisualStudio.ComponentGroup.VC.Tools.142.x86.x64 --quiet --norestart
 
@@ -122,6 +122,12 @@ jobs:
         script: |
           core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
           core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
+    
+    - name: Install MSVC 2019
+      if: ${{ matrix.msvc_version.year == 2019 }}
+      run: |
+        # this is temporary, so please excuse the hardcoded paths
+        & "C:\Program Files (x86)\Microsoft Visual Studio\Installer\vs_installer.exe" modify --installPath "C:\Program Files\Microsoft Visual Studio\2022\Enterprise" --add Microsoft.VisualStudio.ComponentGroup.VC.Tools.142.x86.x64 --quiet --norestart
 
     - name: Set up vcpkg
       run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -19,7 +19,7 @@ jobs:
         - year: 2022
           triplet: x64-windows-static
 
-    name: static-windows-${{ matrix.msvc_version }}
+    name: static-windows-${{ matrix.msvc_version.year }}
 
     runs-on: windows-2022
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -32,12 +32,6 @@ jobs:
         script: |
           core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
           core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
-    
-    - name: Install MSVC 2019
-      if: ${{ matrix.msvc_version.year == 2019 }}
-      run: |
-        # this is temporary, so please excuse the hardcoded paths
-        & "C:\Program Files (x86)\Microsoft Visual Studio\Installer\vs_installer.exe" modify --installPath "C:\Program Files\Microsoft Visual Studio\2022\Enterprise" --add Microsoft.VisualStudio.ComponentGroup.VC.Tools.142.x86.x64 --quiet --norestart
 
     - name: Set up vcpkg
       run: |
@@ -122,12 +116,6 @@ jobs:
         script: |
           core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
           core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
-    
-    - name: Install MSVC 2019
-      if: ${{ matrix.msvc_version.year == 2019 }}
-      run: |
-        # this is temporary, so please excuse the hardcoded paths
-        & "C:\Program Files (x86)\Microsoft Visual Studio\Installer\vs_installer.exe" modify --installPath "C:\Program Files\Microsoft Visual Studio\2022\Enterprise" --add Microsoft.VisualStudio.ComponentGroup.VC.Tools.142.x86.x64 --quiet --norestart
 
     - name: Set up vcpkg
       run: |

--- a/triplets/x64-windows-2019-static.cmake
+++ b/triplets/x64-windows-2019-static.cmake
@@ -1,0 +1,7 @@
+# from x64-windows-static.cmake
+set(VCPKG_TARGET_ARCHITECTURE x64)
+set(VCPKG_CRT_LINKAGE static)
+set(VCPKG_LIBRARY_LINKAGE static)
+
+# to get MSVC 2019
+set(VCPKG_PLATFORM_TOOLSET v142)

--- a/triplets/x64-windows-2019.cmake
+++ b/triplets/x64-windows-2019.cmake
@@ -1,0 +1,7 @@
+# from x64-windows.cmake
+set(VCPKG_TARGET_ARCHITECTURE x64)
+set(VCPKG_CRT_LINKAGE dynamic)
+set(VCPKG_LIBRARY_LINKAGE dynamic)
+
+# to get MSVC 2019
+set(VCPKG_PLATFORM_TOOLSET v142)


### PR DESCRIPTION
It turns out it's got MSVC 2019 installed already (not that the installation command is difficult to figure out), and it's not that hard to tell vcpkg to use a specific compiler version.

Alternative to https://github.com/OpenMW/openmw-deps-build/pull/26